### PR TITLE
add language_server_workspace_configuration trait method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,38 @@ impl Extension for NextflowExtension {
         })
     }
 
+    fn language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &LanguageServerId,
+        _worktree: &Worktree,
+    ) -> zed::Result<Option<zed::serde_json::Value>> {
+        Ok(Some(zed::serde_json::json!({
+            "nextflow": {
+                "completion": {
+                    "extended": false,
+                    "maxItems": 100,
+                },
+                "debug": false,
+                "errorReportingMode": "warnings",
+                "files": {
+                    "exclude": [".git", ".nf-test", "work"],
+                },
+                "formatting": {
+                    "harshilAlignment": false,
+                    "maheshForm": false,
+                    "sortDeclarations": false,
+                },
+                "java": {
+                    "home": "",
+                },
+                "languageVersion": "26.04",
+                "telemetry": {
+                    "enabled": false,
+                },
+            },
+        })))
+    }
+
     fn label_for_completion(
         &self,
         _language_server_id: &LanguageServerId,


### PR DESCRIPTION
hello! 

I've recently moved to Zed and so I am in need of a Nextflow plugin, and came across this one - nice work.

I have been attempting to get workspace features working in Zed, see - https://github.com/nextflow-io/language-server/issues/122#issuecomment-4451957602

This PR implements the `language_server_workspace_configuration` trait method using the defaults I could find in the VScode `package.json` [here](https://github.com/nextflow-io/vscode-language-nextflow/blob/24e6c8410721240fd07ef2378441ccb80ed28e11/package.json#L171). This provides out of the box defaults, but a user should be able to override in the Zed settings if needed.

ATM defaults are needed because the language server [initializeWorkspaces](https://github.com/nextflow-io/language-server/blob/5e9aacf32dd7b6908eb54717ac40fab4c71f99dc/src/main/java/nextflow/lsp/NextflowLanguageServer.java#L489) function is only called from [didChangeConfiguration](https://github.com/nextflow-io/language-server/blob/5e9aacf32dd7b6908eb54717ac40fab4c71f99dc/src/main/java/nextflow/lsp/NextflowLanguageServer.java#L446) - so we need to send a config change to trigger workspace init.

In combination with https://github.com/nextflow-io/language-server/pull/156 I now have inline diagnostics and `ctrl`-click navigation working:

<img width="738" height="430" alt="screenshot-2026-05-14_15-52-47" src="https://github.com/user-attachments/assets/017f672b-726e-4ec0-9d98-ad4e0de1fb0a" />

On a separate note I also updated the pinned nextflow tree sitter version to the latest revision (which only needed some minor changes). I havent included them in this PR but happy to open one if worth updating